### PR TITLE
Async client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,37 @@ crate-type = ["lib", "cdylib", "staticlib"]
 name = "linkding"
 
 [features]
-ffi = ["uniffi"]
+default = ["blocking", "async", "rustls-tls"]
+blocking = ["reqwest/blocking", "reqwest/multipart"]
+async = ["reqwest/multipart"]
+rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+ffi = ["uniffi", "blocking"]
 
 [dependencies]
 http-serde = "2.1.1"
-reqwest = { version = "0.12.15", features = ["blocking", "multipart", "gzip", "json", "brotli", "deflate"] }
+reqwest = { version = "0.12.15", default-features = false, features = ["json", "gzip", "brotli", "deflate"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
 uniffi = { version = "0.29.2", optional = true }
 url = "2.5.4"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+wiremock = "0.6"
+
 [build-dependencies]
 uniffi = { version = "0.29.2", features = ["build"] }
+
+[[example]]
+name = "count_bookmarks"
+required-features = ["blocking"]
+
+[[example]]
+name = "download_asset"
+required-features = ["blocking"]
+
+[[example]]
+name = "upload_asset"
+required-features = ["blocking"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ required-features = ["blocking"]
 [[example]]
 name = "upload_asset"
 required-features = ["blocking"]
+
+[[example]]
+name = "count_bookmarks_async"
+required-features = ["async"]

--- a/README.md
+++ b/README.md
@@ -4,12 +4,52 @@
 [![Docs.rs](https://docs.rs/linkding-rs/badge.svg)](https://docs.rs/linkding-rs)
 [![Build](https://github.com/zbrox/linkding-rs/actions/workflows/build.yml/badge.svg)](https://github.com/zbrox/linkding-rs/actions/workflows/build.yml)
 
-This is a simple synchronous Rust client for the [linkding](https://linkding.link/) API with some cross platform support.
+A Rust client for the [linkding](https://linkding.link/) API with both sync and async support, plus cross platform bindings.
 
 Tested with linkding v1.36.0.
 
+## Cargo features
+
+The crate ships two clients and two TLS backends. By default all are enabled.
+
+| Feature      | Default | What it gives you                                        |
+| ------------ | :-----: | -------------------------------------------------------- |
+| `blocking`   |   yes   | `LinkDingClient` — synchronous, built on blocking reqwest |
+| `async`      |   yes   | `LinkDingAsyncClient` — async, built on tokio + reqwest   |
+| `rustls-tls` |   yes   | TLS via rustls                                           |
+| `native-tls` |   no    | TLS via the system's native TLS stack                    |
+| `ffi`        |   no    | UniFFI scaffolding for the sync client (mobile bindings) |
+
+At least one TLS backend must be enabled. Disable defaults to pick your own:
+
+```toml
+linkding-rs = { version = "0.3", default-features = false, features = ["async", "rustls-tls"] }
+```
+
+## Sync usage
+
+```rust
+use linkding::{LinkDingClient, ListBookmarksArgs};
+
+let client = LinkDingClient::new("https://linkding.local:9090", "YOUR_API_TOKEN");
+let bookmarks = client.list_bookmarks(ListBookmarksArgs::default())?;
+```
+
+## Async usage
+
+```rust
+use linkding::{LinkDingAsyncClient, ListBookmarksArgs};
+
+#[tokio::main]
+async fn main() -> Result<(), linkding::LinkDingError> {
+    let client = LinkDingAsyncClient::new("https://linkding.local:9090", "YOUR_API_TOKEN");
+    let bookmarks = client.list_bookmarks(ListBookmarksArgs::default()).await?;
+    Ok(())
+}
+```
+
 ## Cross platform
 
-There are [Uniffi](https://mozilla.github.io/uniffi-rs/latest/) bindings so you can use this for making Android or iOS apps.
+There are [Uniffi](https://mozilla.github.io/uniffi-rs/latest/) bindings so you can use this for making Android or iOS apps. The bindings expose the synchronous client only; mobile consumers should call from a background thread.
 
-The CI is buidling a Swift package that you can download from the releases page.
+The CI is building a Swift package that you can download from the releases page.

--- a/examples/count_bookmarks.rs
+++ b/examples/count_bookmarks.rs
@@ -13,9 +13,8 @@ fn main() {
     loop {
         let response = linkding_client
             .list_bookmarks(ListBookmarksArgs {
-                query: None,
-                limit: None,
                 offset: Some(offset),
+                ..Default::default()
             })
             .expect("Couldn't fetch bookmarks");
         total_bookmarks += response.results.len();

--- a/examples/count_bookmarks_async.rs
+++ b/examples/count_bookmarks_async.rs
@@ -1,0 +1,30 @@
+use linkding::{LinkDingAsyncClient, ListBookmarksArgs};
+
+#[tokio::main]
+async fn main() {
+    let linkding_host =
+        std::env::var("LINKDING_HOST").unwrap_or("http://localhost:9090".to_string());
+    let linkding_token =
+        std::env::var("LINKDING_TOKEN").expect("LINKDING_TOKEN env variable is not set");
+    let linkding_client = LinkDingAsyncClient::new(&linkding_host, &linkding_token);
+
+    let mut total_bookmarks = 0;
+    let mut offset = 0;
+
+    loop {
+        let response = linkding_client
+            .list_bookmarks(ListBookmarksArgs {
+                offset: Some(offset),
+                ..Default::default()
+            })
+            .await
+            .expect("Couldn't fetch bookmarks");
+        total_bookmarks += response.results.len();
+        if response.next.is_none() {
+            break;
+        }
+        offset += 100;
+    }
+
+    println!("Total bookmarks: {}", total_bookmarks);
+}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,0 +1,259 @@
+use reqwest::{
+    multipart::{Form, Part},
+    StatusCode,
+};
+
+use crate::{
+    bookmark_assets::{BookmarkAsset, ListBookmarkAssetsResponse},
+    bookmarks::{
+        Bookmark, CheckUrlResponse, CreateBookmarkBody, ListBookmarksArgs, ListBookmarksResponse,
+        UpdateBookmarkBody,
+    },
+    build_request_spec,
+    tags::{ListTagsArgs, ListTagsResponse, TagData},
+    users::UserProfile,
+    Endpoint, LinkDingError,
+};
+
+/// An async client for the LinkDing API.
+///
+/// Mirrors [`LinkDingClient`](crate::LinkDingClient) but every method is `async`.
+/// Requires the `async` cargo feature (enabled by default).
+///
+/// # Example
+///
+/// ```no_run
+/// use linkding::{LinkDingAsyncClient, LinkDingError, CreateBookmarkBody};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), LinkDingError> {
+///     let client = LinkDingAsyncClient::new("https://linkding.local:9090", "YOUR_API_TOKEN");
+///     let new_bookmark = CreateBookmarkBody {
+///         url: "https://example.com".to_string(),
+///         ..Default::default()
+///     };
+///     let bookmark = client.create_bookmark(new_bookmark).await?;
+///     println!("Bookmark created: {:?}", bookmark);
+///     client.delete_bookmark(bookmark.id).await?;
+///     println!("Bookmark deleted");
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct LinkDingAsyncClient {
+    token: String,
+    url: String,
+    client: reqwest::Client,
+}
+
+impl LinkDingAsyncClient {
+    pub fn new(url: &str, token: &str) -> Self {
+        LinkDingAsyncClient {
+            token: token.to_string(),
+            url: url.to_string(),
+            client: reqwest::Client::builder()
+                .build()
+                .expect("Could not create web client"),
+        }
+    }
+
+    fn prepare_request(
+        &self,
+        endpoint: Endpoint,
+    ) -> Result<reqwest::RequestBuilder, LinkDingError> {
+        let spec = build_request_spec(&self.url, &self.token, endpoint)?;
+        Ok(self
+            .client
+            .request(spec.method, spec.url)
+            .headers(spec.headers))
+    }
+
+    /// List unarchived bookmarks
+    pub async fn list_bookmarks(
+        &self,
+        args: ListBookmarksArgs,
+    ) -> Result<ListBookmarksResponse, LinkDingError> {
+        let endpoint = Endpoint::ListBookmarks(args);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListBookmarksResponse = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// List archived bookmarks
+    pub async fn list_archived_bookmarks(
+        &self,
+        args: ListBookmarksArgs,
+    ) -> Result<ListBookmarksResponse, LinkDingError> {
+        let endpoint = Endpoint::ListArchivedBookmarks(args);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListBookmarksResponse = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Get a bookmark by ID
+    pub async fn get_bookmark(&self, id: i32) -> Result<Bookmark, LinkDingError> {
+        let endpoint = Endpoint::GetBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: Bookmark = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Check if a URL has been bookmarked
+    pub async fn check_url(&self, url: &str) -> Result<CheckUrlResponse, LinkDingError> {
+        let endpoint = Endpoint::CheckUrl(url.to_string());
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: CheckUrlResponse = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Create a bookmark
+    pub async fn create_bookmark(
+        &self,
+        body: CreateBookmarkBody,
+    ) -> Result<Bookmark, LinkDingError> {
+        let endpoint = Endpoint::CreateBookmark;
+        let request = self
+            .prepare_request(endpoint)?
+            .body(serde_json::to_string(&body)?)
+            .build()?;
+        let body: Bookmark = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Update a bookmark
+    pub async fn update_bookmark(
+        &self,
+        id: i32,
+        body: UpdateBookmarkBody,
+    ) -> Result<Bookmark, LinkDingError> {
+        let endpoint = Endpoint::UpdateBookmark(id);
+        let request = self
+            .prepare_request(endpoint)?
+            .body(serde_json::to_string(&body)?)
+            .build()?;
+        let body: Bookmark = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Archive a bookmark
+    pub async fn archive_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::ArchiveBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request).await?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+
+    /// Take a bookmark out of the archive
+    pub async fn unarchive_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::UnarchiveBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request).await?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+
+    /// Delete a bookmark
+    pub async fn delete_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::DeleteBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request).await?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+
+    /// List tags
+    pub async fn list_tags(&self, args: ListTagsArgs) -> Result<ListTagsResponse, LinkDingError> {
+        let endpoint = Endpoint::ListTags(args);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListTagsResponse = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Get a tag by ID
+    pub async fn get_tag(&self, id: i32) -> Result<TagData, LinkDingError> {
+        let endpoint = Endpoint::GetTag(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: TagData = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Create a tag
+    pub async fn create_tag(&self, name: &str) -> Result<TagData, LinkDingError> {
+        let endpoint = Endpoint::CreateTag;
+        let body = serde_json::json!({ "name": name });
+        let request = self
+            .prepare_request(endpoint)?
+            .body(serde_json::to_string(&body)?)
+            .build()?;
+        let body: TagData = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Get the user's profile
+    pub async fn get_user_profile(&self) -> Result<UserProfile, LinkDingError> {
+        let endpoint = Endpoint::GetUserProfile;
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: UserProfile = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Lists a bookmark's assets
+    pub async fn list_bookmark_assets(
+        &self,
+        id: i32,
+    ) -> Result<ListBookmarkAssetsResponse, LinkDingError> {
+        let endpoint = Endpoint::ListBookmarkAssets(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListBookmarkAssetsResponse =
+            self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Retrieve info for a single asset of a bookmark
+    pub async fn retrieve_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        asset_id: i32,
+    ) -> Result<BookmarkAsset, LinkDingError> {
+        let endpoint = Endpoint::RetrieveBookmarkAsset(bookmark_id, asset_id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: BookmarkAsset = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Download a bookmark's asset
+    pub async fn download_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        asset_id: i32,
+    ) -> Result<Vec<u8>, LinkDingError> {
+        let endpoint = Endpoint::DownloadBookmarkAsset(bookmark_id, asset_id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request).await?;
+        Ok(response.bytes().await?.into())
+    }
+
+    /// Upload an asset for a bookmark
+    pub async fn upload_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        bytes: &[u8],
+    ) -> Result<BookmarkAsset, LinkDingError> {
+        let endpoint = Endpoint::UploadBookmarkAsset(bookmark_id);
+        let bytes_part = Part::bytes(bytes.to_owned());
+        let form = Form::new().part("file", bytes_part);
+        let request = self.prepare_request(endpoint)?.multipart(form).build()?;
+        let body: BookmarkAsset = self.client.execute(request).await?.json().await?;
+        Ok(body)
+    }
+
+    /// Delete a bookmark's asset
+    pub async fn delete_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        asset_id: i32,
+    ) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::DeleteBookmarkAsset(bookmark_id, asset_id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request).await?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+}

--- a/src/bookmark_assets.rs
+++ b/src/bookmark_assets.rs
@@ -7,6 +7,13 @@ pub enum BookmarkAssetType {
     Upload,
     #[default]
     Snapshot,
+    Precrawled,
+    /// Catch-all for asset types Linkding may add in the future.
+    ///
+    /// Note: this variant only carries through deserialisation. If you serialise a
+    /// `BookmarkAsset` that came back as `Unknown`, the original string is lost.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
@@ -29,6 +36,8 @@ pub struct BookmarkAsset {
     pub content_type: String,
     pub display_name: String,
     pub status: BookmarkAssetStatus,
+    #[serde(default)]
+    pub file_size: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -38,4 +47,64 @@ pub struct ListBookmarkAssetsResponse {
     pub next: Option<String>,
     pub previous: Option<String>,
     pub results: Vec<BookmarkAsset>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_type_deserializes_known_variants() {
+        assert_eq!(
+            serde_json::from_str::<BookmarkAssetType>("\"upload\"").unwrap(),
+            BookmarkAssetType::Upload
+        );
+        assert_eq!(
+            serde_json::from_str::<BookmarkAssetType>("\"snapshot\"").unwrap(),
+            BookmarkAssetType::Snapshot
+        );
+        assert_eq!(
+            serde_json::from_str::<BookmarkAssetType>("\"precrawled\"").unwrap(),
+            BookmarkAssetType::Precrawled
+        );
+    }
+
+    #[test]
+    fn asset_type_deserializes_unknown_variant_to_unknown() {
+        assert_eq!(
+            serde_json::from_str::<BookmarkAssetType>("\"weird_future_type\"").unwrap(),
+            BookmarkAssetType::Unknown
+        );
+    }
+
+    #[test]
+    fn bookmark_asset_deserializes_with_file_size() {
+        let json = r#"{
+            "id": 1,
+            "bookmark": 42,
+            "asset_type": "snapshot",
+            "date_created": "2026-04-29T12:00:00Z",
+            "content_type": "text/html",
+            "display_name": "snapshot.html",
+            "status": "complete",
+            "file_size": 12345
+        }"#;
+        let asset: BookmarkAsset = serde_json::from_str(json).unwrap();
+        assert_eq!(asset.file_size, Some(12345));
+    }
+
+    #[test]
+    fn bookmark_asset_deserializes_without_file_size() {
+        let json = r#"{
+            "id": 1,
+            "bookmark": 42,
+            "asset_type": "snapshot",
+            "date_created": "2026-04-29T12:00:00Z",
+            "content_type": "text/html",
+            "display_name": "snapshot.html",
+            "status": "complete"
+        }"#;
+        let asset: BookmarkAsset = serde_json::from_str(json).unwrap();
+        assert_eq!(asset.file_size, None);
+    }
 }

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -122,6 +122,8 @@ pub struct ListBookmarksArgs {
     pub query: Option<String>,
     pub limit: Option<i32>,
     pub offset: Option<i32>,
+    /// Return only bookmarks modified since this RFC 3339 timestamp.
+    pub modified_since: Option<String>,
 }
 
 impl QueryString for ListBookmarksArgs {
@@ -130,10 +132,52 @@ impl QueryString for ListBookmarksArgs {
             ("q", self.query.as_ref().map(|v| v.to_string())),
             ("limit", self.limit.as_ref().map(|v| v.to_string())),
             ("offset", self.offset.as_ref().map(|v| v.to_string())),
+            (
+                "modified_since",
+                self.modified_since.as_ref().map(|v| v.to_string()),
+            ),
         ]
         .iter()
         .filter_map(|(k, v)| v.as_ref().map(|v| format!("{}={}", k, v)))
         .collect::<Vec<_>>()
         .join("&")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_bookmarks_args_emits_modified_since_only() {
+        let args = ListBookmarksArgs {
+            modified_since: Some("2026-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            args.query_string(),
+            "modified_since=2026-01-01T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn list_bookmarks_args_emits_all_fields() {
+        let args = ListBookmarksArgs {
+            query: Some("rust".to_string()),
+            limit: Some(50),
+            offset: Some(10),
+            modified_since: Some("2026-01-01T00:00:00Z".to_string()),
+        };
+        let qs = args.query_string();
+        assert!(qs.contains("q=rust"), "{qs}");
+        assert!(qs.contains("limit=50"), "{qs}");
+        assert!(qs.contains("offset=10"), "{qs}");
+        assert!(qs.contains("modified_since=2026-01-01T00:00:00Z"), "{qs}");
+    }
+
+    #[test]
+    fn list_bookmarks_args_default_is_empty_query() {
+        let args = ListBookmarksArgs::default();
+        assert_eq!(args.query_string(), "");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,26 @@
 #[cfg(feature = "ffi")]
 uniffi::setup_scaffolding!();
 
+#[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+compile_error!(
+    "linkding-rs requires one of the `rustls-tls` or `native-tls` features to be enabled"
+);
+
 pub mod bookmark_assets;
 pub mod bookmarks;
 pub mod tags;
 pub mod users;
 
-use bookmark_assets::{BookmarkAsset, ListBookmarkAssetsResponse};
+#[cfg(feature = "blocking")]
+mod sync_client;
+#[cfg(feature = "blocking")]
+pub use sync_client::LinkDingClient;
+
 pub use bookmarks::{
     Bookmark, CheckUrlResponse, CreateBookmarkBody, ListBookmarksArgs, ListBookmarksResponse,
     UpdateBookmarkBody,
 };
-use reqwest::{
-    blocking::multipart::Part,
-    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE},
-    StatusCode,
-};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 pub use tags::{ListTagsArgs, ListTagsResponse, TagData};
 use thiserror::Error;
 pub use users::{DateDisplay, LinkTarget, SelectedTheme, SortBy, TagSearchMethod, UserProfile};
@@ -237,254 +242,4 @@ pub(crate) fn build_request_spec(
         method,
         headers,
     })
-}
-
-/// A sync client for the LinkDing API.
-///
-/// This client is used to interact with the LinkDing API. It provides methods for
-/// managing bookmarks and tags, the full capability of the LinkDing API.
-///
-/// # Example
-///
-/// ```
-/// use linkding::{LinkDingClient, LinkDingError, CreateBookmarkBody};
-///
-/// fn main() -> Result<(), LinkDingError> {
-///     let client = LinkDingClient::new("https://linkding.local:9090", "YOUR_API_TOKEN");
-///     let new_bookmark = CreateBookmarkBody {
-///         url: "https://example.com".to_string(),
-///         ..Default::default()
-///     };
-///     let bookmark = client.create_bookmark(new_bookmark)?;
-///     println!("Bookmark created: {:?}", bookmark);
-///     client.delete_bookmark(bookmark.id)?;
-///     println!("Bookmark deleted");
-///     Ok(())
-/// }
-/// ```
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "ffi", derive(uniffi::Object))]
-pub struct LinkDingClient {
-    token: String,
-    url: String,
-    client: reqwest::blocking::Client,
-}
-
-impl LinkDingClient {
-    fn prepare_request(
-        &self,
-        endpoint: Endpoint,
-    ) -> Result<reqwest::blocking::RequestBuilder, LinkDingError> {
-        let spec = build_request_spec(&self.url, &self.token, endpoint)?;
-        Ok(self.client.request(spec.method, spec.url).headers(spec.headers))
-    }
-}
-
-#[cfg_attr(feature = "ffi", uniffi::export)]
-impl LinkDingClient {
-    #[cfg_attr(feature = "ffi", uniffi::constructor)]
-    pub fn new(url: &str, token: &str) -> Self {
-        LinkDingClient {
-            token: token.to_string(),
-            url: url.to_string(),
-            client: reqwest::blocking::Client::builder()
-                .build()
-                .expect("Could not create web client"),
-        }
-    }
-
-    /// List unarchived bookmarks
-    pub fn list_bookmarks(
-        &self,
-        args: ListBookmarksArgs,
-    ) -> Result<ListBookmarksResponse, LinkDingError> {
-        let endpoint = Endpoint::ListBookmarks(args);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: ListBookmarksResponse = self.client.execute(request)?.json()?;
-
-        Ok(body)
-    }
-
-    /// List archived bookmarks
-    pub fn list_archived_bookmarks(
-        &self,
-        args: ListBookmarksArgs,
-    ) -> Result<ListBookmarksResponse, LinkDingError> {
-        let endpoint = Endpoint::ListArchivedBookmarks(args);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: ListBookmarksResponse = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Get a bookmark by ID
-    pub fn get_bookmark(&self, id: i32) -> Result<Bookmark, LinkDingError> {
-        let endpoint = Endpoint::GetBookmark(id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: Bookmark = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Check if a URL has been bookmarked
-    ///
-    /// If the URL has already been bookmarked this will return the bookmark
-    /// data, otherwise the bookmark data will be `None`. The metadata of the
-    /// webpage will always be returned.
-    pub fn check_url(&self, url: &str) -> Result<CheckUrlResponse, LinkDingError> {
-        let endpoint = Endpoint::CheckUrl(url.to_string());
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: CheckUrlResponse = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Create a bookmark
-    ///
-    /// If the bookmark already exists, it will be updated with the new data passed in the `body` parameter.
-    pub fn create_bookmark(&self, body: CreateBookmarkBody) -> Result<Bookmark, LinkDingError> {
-        let endpoint = Endpoint::CreateBookmark;
-        let request = self
-            .prepare_request(endpoint)?
-            .body(serde_json::to_string(&body)?)
-            .build()?;
-        let body: Bookmark = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Update a bookmark
-    ///
-    /// Pass only the fields you want to update in the `body` parameter.
-    pub fn update_bookmark(
-        &self,
-        id: i32,
-        body: UpdateBookmarkBody,
-    ) -> Result<Bookmark, LinkDingError> {
-        let endpoint = Endpoint::UpdateBookmark(id);
-        let request = self
-            .prepare_request(endpoint)?
-            .body(serde_json::to_string(&body)?)
-            .build()?;
-        let body: Bookmark = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Archive a bookmark
-    pub fn archive_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
-        let endpoint = Endpoint::ArchiveBookmark(id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let response = self.client.execute(request)?;
-
-        Ok(response.status() == StatusCode::NO_CONTENT)
-    }
-
-    /// Take a bookmark out of the archive
-    pub fn unarchive_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
-        let endpoint = Endpoint::UnarchiveBookmark(id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let response = self.client.execute(request)?;
-        Ok(response.status() == StatusCode::NO_CONTENT)
-    }
-
-    /// Delete a bookmark
-    pub fn delete_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
-        let endpoint = Endpoint::DeleteBookmark(id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let response = self.client.execute(request)?;
-        Ok(response.status() == StatusCode::NO_CONTENT)
-    }
-
-    /// List tags
-    pub fn list_tags(&self, args: ListTagsArgs) -> Result<ListTagsResponse, LinkDingError> {
-        let endpoint = Endpoint::ListTags(args);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: ListTagsResponse = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Get a tag by ID
-    pub fn get_tag(&self, id: i32) -> Result<TagData, LinkDingError> {
-        let endpoint = Endpoint::GetTag(id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: TagData = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Create a tag
-    pub fn create_tag(&self, name: &str) -> Result<TagData, LinkDingError> {
-        let endpoint = Endpoint::CreateTag;
-        let body = serde_json::json!({ "name": name });
-        let request = self
-            .prepare_request(endpoint)?
-            .body(serde_json::to_string(&body)?)
-            .build()?;
-        let body: TagData = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Get the user's profile
-    pub fn get_user_profile(&self) -> Result<UserProfile, LinkDingError> {
-        let endpoint = Endpoint::GetUserProfile;
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: UserProfile = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Lists a bookmarks' assets
-    pub fn list_bookmark_assets(
-        &self,
-        id: i32,
-    ) -> Result<ListBookmarkAssetsResponse, LinkDingError> {
-        let endpoint = Endpoint::ListBookmarkAssets(id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: ListBookmarkAssetsResponse = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Retrieve info for a single asset of a bookmark
-    pub fn retrieve_bookmark_asset(
-        &self,
-        bookmark_id: i32,
-        asset_id: i32,
-    ) -> Result<BookmarkAsset, LinkDingError> {
-        let endpoint = Endpoint::RetrieveBookmarkAsset(bookmark_id, asset_id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let body: BookmarkAsset = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Download a bookmark's asset
-    pub fn download_bookmark_asset(
-        &self,
-        bookmark_id: i32,
-        asset_id: i32,
-    ) -> Result<Vec<u8>, LinkDingError> {
-        let endpoint = Endpoint::DownloadBookmarkAsset(bookmark_id, asset_id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let response = self.client.execute(request)?;
-        Ok(response.bytes()?.into())
-    }
-
-    /// Upload an asset for a bookmark
-    pub fn upload_bookmark_asset(
-        &self,
-        bookmark_id: i32,
-        bytes: &[u8],
-    ) -> Result<BookmarkAsset, LinkDingError> {
-        let endpoint = Endpoint::UploadBookmarkAsset(bookmark_id);
-        let bytes_part = Part::bytes(bytes.to_owned());
-        let form = reqwest::blocking::multipart::Form::new().part("file", bytes_part);
-        let request = self.prepare_request(endpoint)?.multipart(form).build()?;
-        let body: BookmarkAsset = self.client.execute(request)?.json()?;
-        Ok(body)
-    }
-
-    /// Delete a bookmark's asset
-    pub fn delete_bookmark_asset(
-        &self,
-        bookmark_id: i32,
-        asset_id: i32,
-    ) -> Result<bool, LinkDingError> {
-        let endpoint = Endpoint::DeleteBookmarkAsset(bookmark_id, asset_id);
-        let request = self.prepare_request(endpoint)?.build()?;
-        let response = self.client.execute(request)?;
-        Ok(response.status() == StatusCode::NO_CONTENT)
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,6 @@ pub enum LinkDingError {
     ParseUrl(url::ParseError),
     #[error("Error sending HTTP request")]
     SendHttpError(#[from] reqwest::Error),
-    #[error("Could not parse response from API")]
-    ParseResponse(#[from] std::io::Error),
     #[error("Could not serialize JSON body")]
     JsonSerialize(#[from] serde_json::Error),
 }
@@ -210,6 +208,37 @@ trait QueryString {
     fn query_string(&self) -> String;
 }
 
+pub(crate) struct RequestSpec {
+    pub url: reqwest::Url,
+    pub method: reqwest::Method,
+    pub headers: reqwest::header::HeaderMap,
+}
+
+pub(crate) fn build_request_spec(
+    base_url: &str,
+    token: &str,
+    endpoint: Endpoint,
+) -> Result<RequestSpec, LinkDingError> {
+    let base: reqwest::Url = base_url.parse().map_err(LinkDingError::ParseUrl)?;
+    let path_and_query: String = endpoint.clone().into();
+    let url = base
+        .join(&path_and_query)
+        .map_err(LinkDingError::ParseUrl)?;
+    let method: reqwest::Method = endpoint.clone().into();
+    let mut headers: reqwest::header::HeaderMap = endpoint.into();
+    headers.insert(
+        AUTHORIZATION,
+        format!("Token {}", token)
+            .parse()
+            .expect("Could not parse authorization header value"),
+    );
+    Ok(RequestSpec {
+        url,
+        method,
+        headers,
+    })
+}
+
 /// A sync client for the LinkDing API.
 ///
 /// This client is used to interact with the LinkDing API. It provides methods for
@@ -246,23 +275,8 @@ impl LinkDingClient {
         &self,
         endpoint: Endpoint,
     ) -> Result<reqwest::blocking::RequestBuilder, LinkDingError> {
-        let base_url: reqwest::Url = self.url.parse().map_err(LinkDingError::ParseUrl)?;
-        let path_and_query: String = endpoint.clone().into();
-        let url = base_url
-            .join(&path_and_query)
-            .map_err(LinkDingError::ParseUrl)?;
-        let method: reqwest::Method = endpoint.clone().into();
-        let mut endpoint_headers: reqwest::header::HeaderMap = endpoint.clone().into();
-        endpoint_headers.insert(
-            AUTHORIZATION,
-            format!("Token {}", &self.token)
-                .parse()
-                .expect("Could not parse authorization header value"),
-        );
-
-        let builder = self.client.request(method, url).headers(endpoint_headers);
-
-        Ok(builder)
+        let spec = build_request_spec(&self.url, &self.token, endpoint)?;
+        Ok(self.client.request(spec.method, spec.url).headers(spec.headers))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@ mod sync_client;
 #[cfg(feature = "blocking")]
 pub use sync_client::LinkDingClient;
 
+#[cfg(feature = "async")]
+mod async_client;
+#[cfg(feature = "async")]
+pub use async_client::LinkDingAsyncClient;
+
 pub use bookmarks::{
     Bookmark, CheckUrlResponse, CreateBookmarkBody, ListBookmarksArgs, ListBookmarksResponse,
     UpdateBookmarkBody,

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -1,0 +1,269 @@
+use reqwest::{
+    blocking::multipart::{Form, Part},
+    StatusCode,
+};
+
+use crate::{
+    bookmark_assets::{BookmarkAsset, ListBookmarkAssetsResponse},
+    bookmarks::{
+        Bookmark, CheckUrlResponse, CreateBookmarkBody, ListBookmarksArgs, ListBookmarksResponse,
+        UpdateBookmarkBody,
+    },
+    build_request_spec,
+    tags::{ListTagsArgs, ListTagsResponse, TagData},
+    users::UserProfile,
+    Endpoint, LinkDingError,
+};
+
+/// A sync client for the LinkDing API.
+///
+/// This client is used to interact with the LinkDing API. It provides methods for
+/// managing bookmarks and tags, the full capability of the LinkDing API.
+///
+/// # Example
+///
+/// ```no_run
+/// use linkding::{LinkDingClient, LinkDingError, CreateBookmarkBody};
+///
+/// fn main() -> Result<(), LinkDingError> {
+///     let client = LinkDingClient::new("https://linkding.local:9090", "YOUR_API_TOKEN");
+///     let new_bookmark = CreateBookmarkBody {
+///         url: "https://example.com".to_string(),
+///         ..Default::default()
+///     };
+///     let bookmark = client.create_bookmark(new_bookmark)?;
+///     println!("Bookmark created: {:?}", bookmark);
+///     client.delete_bookmark(bookmark.id)?;
+///     println!("Bookmark deleted");
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(uniffi::Object))]
+pub struct LinkDingClient {
+    token: String,
+    url: String,
+    client: reqwest::blocking::Client,
+}
+
+impl LinkDingClient {
+    fn prepare_request(
+        &self,
+        endpoint: Endpoint,
+    ) -> Result<reqwest::blocking::RequestBuilder, LinkDingError> {
+        let spec = build_request_spec(&self.url, &self.token, endpoint)?;
+        Ok(self
+            .client
+            .request(spec.method, spec.url)
+            .headers(spec.headers))
+    }
+}
+
+#[cfg_attr(feature = "ffi", uniffi::export)]
+impl LinkDingClient {
+    #[cfg_attr(feature = "ffi", uniffi::constructor)]
+    pub fn new(url: &str, token: &str) -> Self {
+        LinkDingClient {
+            token: token.to_string(),
+            url: url.to_string(),
+            client: reqwest::blocking::Client::builder()
+                .build()
+                .expect("Could not create web client"),
+        }
+    }
+
+    /// List unarchived bookmarks
+    pub fn list_bookmarks(
+        &self,
+        args: ListBookmarksArgs,
+    ) -> Result<ListBookmarksResponse, LinkDingError> {
+        let endpoint = Endpoint::ListBookmarks(args);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListBookmarksResponse = self.client.execute(request)?.json()?;
+
+        Ok(body)
+    }
+
+    /// List archived bookmarks
+    pub fn list_archived_bookmarks(
+        &self,
+        args: ListBookmarksArgs,
+    ) -> Result<ListBookmarksResponse, LinkDingError> {
+        let endpoint = Endpoint::ListArchivedBookmarks(args);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListBookmarksResponse = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Get a bookmark by ID
+    pub fn get_bookmark(&self, id: i32) -> Result<Bookmark, LinkDingError> {
+        let endpoint = Endpoint::GetBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: Bookmark = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Check if a URL has been bookmarked
+    ///
+    /// If the URL has already been bookmarked this will return the bookmark
+    /// data, otherwise the bookmark data will be `None`. The metadata of the
+    /// webpage will always be returned.
+    pub fn check_url(&self, url: &str) -> Result<CheckUrlResponse, LinkDingError> {
+        let endpoint = Endpoint::CheckUrl(url.to_string());
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: CheckUrlResponse = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Create a bookmark
+    ///
+    /// If the bookmark already exists, it will be updated with the new data passed in the `body` parameter.
+    pub fn create_bookmark(&self, body: CreateBookmarkBody) -> Result<Bookmark, LinkDingError> {
+        let endpoint = Endpoint::CreateBookmark;
+        let request = self
+            .prepare_request(endpoint)?
+            .body(serde_json::to_string(&body)?)
+            .build()?;
+        let body: Bookmark = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Update a bookmark
+    ///
+    /// Pass only the fields you want to update in the `body` parameter.
+    pub fn update_bookmark(
+        &self,
+        id: i32,
+        body: UpdateBookmarkBody,
+    ) -> Result<Bookmark, LinkDingError> {
+        let endpoint = Endpoint::UpdateBookmark(id);
+        let request = self
+            .prepare_request(endpoint)?
+            .body(serde_json::to_string(&body)?)
+            .build()?;
+        let body: Bookmark = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Archive a bookmark
+    pub fn archive_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::ArchiveBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request)?;
+
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+
+    /// Take a bookmark out of the archive
+    pub fn unarchive_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::UnarchiveBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request)?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+
+    /// Delete a bookmark
+    pub fn delete_bookmark(&self, id: i32) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::DeleteBookmark(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request)?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+
+    /// List tags
+    pub fn list_tags(&self, args: ListTagsArgs) -> Result<ListTagsResponse, LinkDingError> {
+        let endpoint = Endpoint::ListTags(args);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListTagsResponse = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Get a tag by ID
+    pub fn get_tag(&self, id: i32) -> Result<TagData, LinkDingError> {
+        let endpoint = Endpoint::GetTag(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: TagData = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Create a tag
+    pub fn create_tag(&self, name: &str) -> Result<TagData, LinkDingError> {
+        let endpoint = Endpoint::CreateTag;
+        let body = serde_json::json!({ "name": name });
+        let request = self
+            .prepare_request(endpoint)?
+            .body(serde_json::to_string(&body)?)
+            .build()?;
+        let body: TagData = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Get the user's profile
+    pub fn get_user_profile(&self) -> Result<UserProfile, LinkDingError> {
+        let endpoint = Endpoint::GetUserProfile;
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: UserProfile = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Lists a bookmarks' assets
+    pub fn list_bookmark_assets(
+        &self,
+        id: i32,
+    ) -> Result<ListBookmarkAssetsResponse, LinkDingError> {
+        let endpoint = Endpoint::ListBookmarkAssets(id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: ListBookmarkAssetsResponse = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Retrieve info for a single asset of a bookmark
+    pub fn retrieve_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        asset_id: i32,
+    ) -> Result<BookmarkAsset, LinkDingError> {
+        let endpoint = Endpoint::RetrieveBookmarkAsset(bookmark_id, asset_id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let body: BookmarkAsset = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Download a bookmark's asset
+    pub fn download_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        asset_id: i32,
+    ) -> Result<Vec<u8>, LinkDingError> {
+        let endpoint = Endpoint::DownloadBookmarkAsset(bookmark_id, asset_id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request)?;
+        Ok(response.bytes()?.into())
+    }
+
+    /// Upload an asset for a bookmark
+    pub fn upload_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        bytes: &[u8],
+    ) -> Result<BookmarkAsset, LinkDingError> {
+        let endpoint = Endpoint::UploadBookmarkAsset(bookmark_id);
+        let bytes_part = Part::bytes(bytes.to_owned());
+        let form = Form::new().part("file", bytes_part);
+        let request = self.prepare_request(endpoint)?.multipart(form).build()?;
+        let body: BookmarkAsset = self.client.execute(request)?.json()?;
+        Ok(body)
+    }
+
+    /// Delete a bookmark's asset
+    pub fn delete_bookmark_asset(
+        &self,
+        bookmark_id: i32,
+        asset_id: i32,
+    ) -> Result<bool, LinkDingError> {
+        let endpoint = Endpoint::DeleteBookmarkAsset(bookmark_id, asset_id);
+        let request = self.prepare_request(endpoint)?.build()?;
+        let response = self.client.execute(request)?;
+        Ok(response.status() == StatusCode::NO_CONTENT)
+    }
+}

--- a/tests/async_client.rs
+++ b/tests/async_client.rs
@@ -1,0 +1,108 @@
+#![cfg(feature = "async")]
+
+use linkding::{
+    bookmark_assets::{BookmarkAssetType, ListBookmarkAssetsResponse},
+    LinkDingAsyncClient, ListBookmarksArgs,
+};
+use wiremock::{
+    matchers::{header, method, path, query_param},
+    Mock, MockServer, ResponseTemplate,
+};
+
+mod common;
+use common::{ASSETS_PAYLOAD, SINGLE_BOOKMARK_PAYLOAD};
+
+const TOKEN: &str = "test-token";
+
+fn client(server: &MockServer) -> LinkDingAsyncClient {
+    LinkDingAsyncClient::new(&server.uri(), TOKEN)
+}
+
+#[tokio::test]
+async fn list_bookmarks_sends_modified_since_and_auth_header() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/bookmarks/"))
+        .and(query_param("modified_since", "2026-01-01T00:00:00Z"))
+        .and(query_param("limit", "50"))
+        .and(header("authorization", format!("Token {TOKEN}").as_str()))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(format!(
+                r#"{{"count":1,"next":null,"previous":null,"results":[{}]}}"#,
+                SINGLE_BOOKMARK_PAYLOAD
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let resp = client(&server)
+        .list_bookmarks(ListBookmarksArgs {
+            limit: Some(50),
+            modified_since: Some("2026-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("list_bookmarks");
+    assert_eq!(resp.count, 1);
+    assert_eq!(resp.results[0].id, 42);
+}
+
+#[tokio::test]
+async fn list_assets_handles_all_variants_including_unknown() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/bookmarks/42/assets/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(ASSETS_PAYLOAD))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let resp: ListBookmarkAssetsResponse = client(&server)
+        .list_bookmark_assets(42)
+        .await
+        .expect("list_bookmark_assets");
+    assert_eq!(resp.results.len(), 4);
+    assert!(matches!(resp.results[0].asset_type, BookmarkAssetType::Snapshot));
+    assert_eq!(resp.results[0].file_size, Some(12345));
+    assert!(matches!(resp.results[1].asset_type, BookmarkAssetType::Upload));
+    assert_eq!(resp.results[1].file_size, None);
+    assert!(matches!(resp.results[2].asset_type, BookmarkAssetType::Precrawled));
+    assert!(matches!(resp.results[3].asset_type, BookmarkAssetType::Unknown));
+}
+
+#[tokio::test]
+async fn download_asset_returns_raw_bytes_with_wildcard_accept() {
+    let server = MockServer::start().await;
+    let bytes = b"<html>snapshot</html>";
+    Mock::given(method("GET"))
+        .and(path("/api/bookmarks/42/assets/1/download/"))
+        .and(header("accept", "*/*"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(bytes.to_vec()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = client(&server)
+        .download_bookmark_asset(42, 1)
+        .await
+        .expect("download_bookmark_asset");
+    assert_eq!(result, bytes);
+}
+
+#[tokio::test]
+async fn http_error_surfaces_as_send_http_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/bookmarks/999/"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    // 404 still parses-as-JSON-failure (response body is empty), surfacing as SendHttpError
+    let err = client(&server)
+        .get_bookmark(999)
+        .await
+        .expect_err("expected error on 404");
+    assert!(matches!(err, linkding::LinkDingError::SendHttpError(_)));
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,66 @@
+/// Sample list-bookmark-assets payload exercising every asset type variant
+/// (including a forward-looking `weird_future_type` to verify `Unknown` parsing)
+/// and an asset with an explicit `file_size` field.
+pub const ASSETS_PAYLOAD: &str = r#"{
+    "count": 4,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "bookmark": 42,
+            "asset_type": "snapshot",
+            "date_created": "2026-04-01T12:00:00Z",
+            "content_type": "text/html",
+            "display_name": "snapshot.html",
+            "status": "complete",
+            "file_size": 12345
+        },
+        {
+            "id": 2,
+            "bookmark": 42,
+            "asset_type": "upload",
+            "date_created": "2026-04-02T12:00:00Z",
+            "content_type": "application/pdf",
+            "display_name": "paper.pdf",
+            "status": "complete"
+        },
+        {
+            "id": 3,
+            "bookmark": 42,
+            "asset_type": "precrawled",
+            "date_created": "2026-04-03T12:00:00Z",
+            "content_type": "text/html",
+            "display_name": "precrawled.html",
+            "status": "pending"
+        },
+        {
+            "id": 4,
+            "bookmark": 42,
+            "asset_type": "weird_future_type",
+            "date_created": "2026-04-04T12:00:00Z",
+            "content_type": "application/octet-stream",
+            "display_name": "future.bin",
+            "status": "complete"
+        }
+    ]
+}"#;
+
+pub const SINGLE_BOOKMARK_PAYLOAD: &str = r#"{
+    "id": 42,
+    "url": "https://example.com",
+    "title": "Example",
+    "description": "An example bookmark",
+    "notes": "",
+    "web_archive_snapshot_url": "",
+    "favicon_url": null,
+    "preview_image_url": null,
+    "is_archived": false,
+    "unread": false,
+    "shared": false,
+    "tag_names": ["rust", "linkding"],
+    "date_added": "2026-04-01T00:00:00Z",
+    "date_modified": "2026-04-15T00:00:00Z",
+    "website_title": "Example",
+    "website_description": null
+}"#;

--- a/tests/sync_client.rs
+++ b/tests/sync_client.rs
@@ -1,0 +1,129 @@
+#![cfg(feature = "blocking")]
+
+use linkding::{
+    bookmark_assets::{BookmarkAssetType, ListBookmarkAssetsResponse},
+    LinkDingClient, ListBookmarksArgs,
+};
+use wiremock::{
+    matchers::{header, method, path, query_param},
+    Mock, MockServer, ResponseTemplate,
+};
+
+mod common;
+use common::{ASSETS_PAYLOAD, SINGLE_BOOKMARK_PAYLOAD};
+
+const TOKEN: &str = "test-token";
+
+/// Run an async setup block on a fresh runtime, returning the started mock
+/// server. The sync client then talks to it from the test thread.
+fn with_mock_server<F>(setup: F) -> (tokio::runtime::Runtime, MockServer)
+where
+    F: std::future::Future<Output = MockServer>,
+{
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let server = rt.block_on(setup);
+    (rt, server)
+}
+
+fn client(server: &MockServer) -> LinkDingClient {
+    LinkDingClient::new(&server.uri(), TOKEN)
+}
+
+#[test]
+fn list_bookmarks_sends_modified_since_and_auth_header() {
+    let (_rt, server) = with_mock_server(async {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/bookmarks/"))
+            .and(query_param("modified_since", "2026-01-01T00:00:00Z"))
+            .and(query_param("limit", "50"))
+            .and(header("authorization", format!("Token {TOKEN}").as_str()))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(format!(
+                    r#"{{"count":1,"next":null,"previous":null,"results":[{}]}}"#,
+                    SINGLE_BOOKMARK_PAYLOAD
+                )),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let resp = client(&server)
+        .list_bookmarks(ListBookmarksArgs {
+            limit: Some(50),
+            modified_since: Some("2026-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        })
+        .expect("list_bookmarks");
+    assert_eq!(resp.count, 1);
+    assert_eq!(resp.results[0].id, 42);
+}
+
+#[test]
+fn list_assets_handles_all_variants_including_unknown() {
+    let (_rt, server) = with_mock_server(async {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/bookmarks/42/assets/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(ASSETS_PAYLOAD))
+            .expect(1)
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let resp: ListBookmarkAssetsResponse = client(&server)
+        .list_bookmark_assets(42)
+        .expect("list_bookmark_assets");
+    assert_eq!(resp.results.len(), 4);
+    assert!(matches!(resp.results[0].asset_type, BookmarkAssetType::Snapshot));
+    assert_eq!(resp.results[0].file_size, Some(12345));
+    assert!(matches!(resp.results[1].asset_type, BookmarkAssetType::Upload));
+    assert_eq!(resp.results[1].file_size, None);
+    assert!(matches!(resp.results[2].asset_type, BookmarkAssetType::Precrawled));
+    assert!(matches!(resp.results[3].asset_type, BookmarkAssetType::Unknown));
+}
+
+#[test]
+fn download_asset_returns_raw_bytes_with_wildcard_accept() {
+    let (_rt, server) = with_mock_server(async {
+        let server = MockServer::start().await;
+        let bytes = b"<html>snapshot</html>";
+        Mock::given(method("GET"))
+            .and(path("/api/bookmarks/42/assets/1/download/"))
+            .and(header("accept", "*/*"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bytes.to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let result = client(&server)
+        .download_bookmark_asset(42, 1)
+        .expect("download_bookmark_asset");
+    assert_eq!(result, b"<html>snapshot</html>");
+}
+
+#[test]
+fn http_error_surfaces_as_send_http_error() {
+    let (_rt, server) = with_mock_server(async {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/bookmarks/999/"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let err = client(&server)
+        .get_bookmark(999)
+        .expect_err("expected error on 404");
+    assert!(matches!(err, linkding::LinkDingError::SendHttpError(_)));
+}


### PR DESCRIPTION
Adds an async client alongside the existing sync one, plus a Cargo feature matrix (`blocking` / `async` / `rustls-tls` / `native-tls`) defaulting to `rustls` and `async`. Also lands some more additions to models like `ListBookmarksArgs::modified_since`, `BookmarkAssetType::Precrawled`, and a forward compatibility `Unknown` variant.
This also drops the unused `LinkDingError::ParseResponse(io::Error)` variant.